### PR TITLE
Adds zoomed-in area with crosshair for finer corner selection

### DIFF
--- a/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/components/polygon/PolygonPointImageView.kt
+++ b/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/components/polygon/PolygonPointImageView.kt
@@ -23,6 +23,7 @@ import android.content.Context
 import android.graphics.PointF
 import android.util.AttributeSet
 import android.view.MotionEvent
+import android.view.ViewConfiguration
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.ContextCompat
 import com.zynksoftware.documentscanner.R
@@ -35,9 +36,15 @@ internal class PolygonPointImageView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : AppCompatImageView(context, attrs, defStyleAttr) {
 
-    companion object {
-        private const val POSITION_HISTORY_WINDOW_MS = 300L
-    }
+    // How far back in time to retain positions for slop analysis.
+    // ViewConfiguration.getTapTimeout() is the system-defined duration after which a press is no
+    // longer considered a tap (~100 ms), which matches our "recent jitter window" intent exactly.
+    private val positionHistoryWindowMs: Long = ViewConfiguration.getTapTimeout().toLong()
+
+    // Pixel distance below which movement is considered a micro-jitter.
+    // scaledTouchSlop is the system value for the minimum distance a touch must travel to be
+    // treated as a scroll/drag, already scaled for the device's screen density.
+    private val touchSlopPx: Float = ViewConfiguration.get(context).scaledTouchSlop.toFloat()
 
     private data class TimedPosition(val timestampMs: Long, val point: PointF)
 
@@ -74,7 +81,7 @@ internal class PolygonPointImageView @JvmOverloads constructor(
                 }
 
                 MotionEvent.ACTION_UP -> {
-                    snapToOldestRecordedPosition()
+                    snapToStablePosition()
                     performClick()
                     dispatchCornerTouchEvent(MotionEvent.ACTION_UP)
                     positionHistory.clear()
@@ -100,17 +107,43 @@ internal class PolygonPointImageView @JvmOverloads constructor(
     }
 
     private fun recordPosition(timestampMs: Long) {
-        val cutoff = timestampMs - POSITION_HISTORY_WINDOW_MS
+        val cutoff = timestampMs - positionHistoryWindowMs
         while (positionHistory.isNotEmpty() && positionHistory.first.timestampMs < cutoff) {
             positionHistory.removeFirst()
         }
         positionHistory.addLast(TimedPosition(timestampMs, PointF(x, y)))
     }
 
-    private fun snapToOldestRecordedPosition() {
-        val oldestPosition = positionHistory.firstOrNull() ?: return
-        x = oldestPosition.point.x
-        y = oldestPosition.point.y
+    /**
+     * Walk backwards through recent history. As long as each step is smaller than
+     * TOUCH_SLOP_PX we treat those samples as jitter and keep going further back.
+     * The first sample we find whose movement *into* it was larger than the slop is
+     * the last "intentional" position, and we snap to it.
+     * If all recorded movement is below slop (the finger barely moved), we keep the
+     * current position unchanged.
+     */
+    private fun snapToStablePosition() {
+        val history = positionHistory.toList()
+        if (history.size < 2) return
+
+        // Start from the newest sample and walk toward older ones.
+        var stableIndex = history.lastIndex
+        for (i in history.lastIndex downTo 1) {
+            val dx = history[i].point.x - history[i - 1].point.x
+            val dy = history[i].point.y - history[i - 1].point.y
+            val dist = Math.hypot(dx.toDouble(), dy.toDouble()).toFloat()
+            if (dist < touchSlopPx) {
+                // This step was jitter – look one frame further back.
+                stableIndex = i - 1
+            } else {
+                // Movement was intentional; stop here.
+                break
+            }
+        }
+
+        val stable = history[stableIndex]
+        x = stable.point.x
+        y = stable.point.y
     }
 
     // Because we call this from onTouchEvent, this code will be executed for both

--- a/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/components/polygon/PolygonPointImageView.kt
+++ b/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/components/polygon/PolygonPointImageView.kt
@@ -52,16 +52,39 @@ internal class PolygonPointImageView @JvmOverloads constructor(
                         y = startPoint.y + mv.y
                         startPoint = PointF(x, y)
                     }
+                    polygonView.dispatchCornerTouchEvent(
+                        MotionEvent.ACTION_MOVE,
+                        event.rawX,
+                        event.rawY
+                    )
                 }
 
                 MotionEvent.ACTION_DOWN -> {
                     downPoint.x = event.x
                     downPoint.y = event.y
                     startPoint = PointF(x, y)
+                    polygonView.dispatchCornerTouchEvent(
+                        MotionEvent.ACTION_DOWN,
+                        event.rawX,
+                        event.rawY
+                    )
                 }
 
                 MotionEvent.ACTION_UP -> {
                     performClick()
+                    polygonView.dispatchCornerTouchEvent(
+                        MotionEvent.ACTION_UP,
+                        event.rawX,
+                        event.rawY
+                    )
+                }
+
+                MotionEvent.ACTION_CANCEL -> {
+                    polygonView.dispatchCornerTouchEvent(
+                        MotionEvent.ACTION_CANCEL,
+                        event.rawX,
+                        event.rawY
+                    )
                 }
             }
             polygonView.invalidate()

--- a/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/components/polygon/PolygonPointImageView.kt
+++ b/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/components/polygon/PolygonPointImageView.kt
@@ -26,6 +26,7 @@ import android.view.MotionEvent
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.ContextCompat
 import com.zynksoftware.documentscanner.R
+import java.util.ArrayDeque
 
 internal class PolygonPointImageView @JvmOverloads constructor(
     context: Context,
@@ -34,8 +35,15 @@ internal class PolygonPointImageView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : AppCompatImageView(context, attrs, defStyleAttr) {
 
+    companion object {
+        private const val POSITION_HISTORY_WINDOW_MS = 300L
+    }
+
+    private data class TimedPosition(val timestampMs: Long, val point: PointF)
+
     private var downPoint = PointF()
-    private var startPoint = PointF()
+    private var parentTopLeft = PointF()
+    private val positionHistory = ArrayDeque<TimedPosition>()
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         super.onTouchEvent(event)
@@ -43,53 +51,66 @@ internal class PolygonPointImageView @JvmOverloads constructor(
         if (polygonView != null) {
             when (event.action) {
                 MotionEvent.ACTION_MOVE -> {
-                    val mv = PointF(event.x - downPoint.x, event.y - downPoint.y)
-                    if (startPoint.x + mv.x + width < polygonView.width &&
-                        startPoint.y + mv.y + height < polygonView.height &&
-                        startPoint.x + mv.x > 0 && startPoint.y + mv.y > 0
-                    ) {
-                        x = startPoint.x + mv.x
-                        y = startPoint.y + mv.y
-                        startPoint = PointF(x, y)
-                    }
-                    polygonView.dispatchCornerTouchEvent(
-                        MotionEvent.ACTION_MOVE,
-                        event.rawX,
-                        event.rawY
-                    )
+                    val nextX = (event.rawX - parentTopLeft.x - downPoint.x)
+                        .coerceIn(0f, (polygonView.width - width).toFloat())
+                    val nextY = (event.rawY - parentTopLeft.y - downPoint.y)
+                        .coerceIn(0f, (polygonView.height - height).toFloat())
+
+                    x = nextX
+                    y = nextY
+                    recordPosition(event.eventTime)
+                    dispatchCornerTouchEvent(MotionEvent.ACTION_MOVE)
                 }
 
                 MotionEvent.ACTION_DOWN -> {
                     downPoint.x = event.x
                     downPoint.y = event.y
-                    startPoint = PointF(x, y)
-                    polygonView.dispatchCornerTouchEvent(
-                        MotionEvent.ACTION_DOWN,
-                        event.rawX,
-                        event.rawY
-                    )
+                    val parentLocation = IntArray(2)
+                    polygonView.getLocationOnScreen(parentLocation)
+                    parentTopLeft = PointF(parentLocation[0].toFloat(), parentLocation[1].toFloat())
+                    positionHistory.clear()
+                    recordPosition(event.eventTime)
+                    dispatchCornerTouchEvent(MotionEvent.ACTION_DOWN)
                 }
 
                 MotionEvent.ACTION_UP -> {
+                    snapToOldestRecordedPosition()
                     performClick()
-                    polygonView.dispatchCornerTouchEvent(
-                        MotionEvent.ACTION_UP,
-                        event.rawX,
-                        event.rawY
-                    )
+                    dispatchCornerTouchEvent(MotionEvent.ACTION_UP)
+                    positionHistory.clear()
                 }
 
                 MotionEvent.ACTION_CANCEL -> {
-                    polygonView.dispatchCornerTouchEvent(
-                        MotionEvent.ACTION_CANCEL,
-                        event.rawX,
-                        event.rawY
-                    )
+                    dispatchCornerTouchEvent(MotionEvent.ACTION_CANCEL)
+                    positionHistory.clear()
                 }
             }
             polygonView.invalidate()
         }
         return true
+    }
+
+    private fun dispatchCornerTouchEvent(action: Int) {
+        val polygon = polygonView ?: return
+        val location = IntArray(2)
+        getLocationOnScreen(location)
+        val centerRawX = location[0] + width / 2f
+        val centerRawY = location[1] + height / 2f
+        polygon.dispatchCornerTouchEvent(action, centerRawX, centerRawY)
+    }
+
+    private fun recordPosition(timestampMs: Long) {
+        val cutoff = timestampMs - POSITION_HISTORY_WINDOW_MS
+        while (positionHistory.isNotEmpty() && positionHistory.first.timestampMs < cutoff) {
+            positionHistory.removeFirst()
+        }
+        positionHistory.addLast(TimedPosition(timestampMs, PointF(x, y)))
+    }
+
+    private fun snapToOldestRecordedPosition() {
+        val oldestPosition = positionHistory.firstOrNull() ?: return
+        x = oldestPosition.point.x
+        y = oldestPosition.point.y
     }
 
     // Because we call this from onTouchEvent, this code will be executed for both

--- a/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/components/polygon/PolygonView.kt
+++ b/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/components/polygon/PolygonView.kt
@@ -39,6 +39,8 @@ internal class PolygonView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
 
+    var onCornerTouchEvent: ((action: Int, rawX: Float, rawY: Float) -> Unit)? = null
+
     var paint: Paint = Paint()
     private var pointer1: ImageView
     private var pointer2: ImageView
@@ -185,5 +187,9 @@ internal class PolygonView @JvmOverloads constructor(
         imageView.x = x.toFloat()
         imageView.y = y.toFloat()
         return imageView
+    }
+
+    fun dispatchCornerTouchEvent(action: Int, rawX: Float, rawY: Float) {
+        onCornerTouchEvent?.invoke(action, rawX, rawY)
     }
 }

--- a/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/imagecrop/ImageCropFragment.kt
+++ b/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/imagecrop/ImageCropFragment.kt
@@ -52,8 +52,9 @@ internal class ImageCropFragment : BaseFragment() {
     companion object {
         private val TAG = ImageCropFragment::class.simpleName
         private const val ZOOM_SCALE = 4f
-        private const val ZOOM_SECTION_RATIO = 0.2f
+        private const val ZOOM_SECTION_RATIO = 0.3f
         private const val ZOOM_MARGIN_RATIO = 0.025f
+        private const val ZOOM_DEAD_ZONE_RATIO = 0.2f
 
         fun newInstance(): ImageCropFragment {
             return ImageCropFragment()
@@ -63,9 +64,12 @@ internal class ImageCropFragment : BaseFragment() {
     private val nativeClass = OpenCvNativeBridge()
 
     private var selectedImage: Bitmap? = null
-    private var zoomSectionSizePx = 0
+    private var zoomSectionWidthPx = 0
+    private var zoomSectionHeightPx = 0
     private var zoomMarginXPx = 0
     private var zoomMarginYPx = 0
+    private var previewOnRightSide: Boolean? = null
+    private var previewOnBottomSide: Boolean? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -126,14 +130,16 @@ internal class ImageCropFragment : BaseFragment() {
             return
         }
 
-        zoomSectionSizePx = (minOf(containerWidth, containerHeight) * ZOOM_SECTION_RATIO).toInt()
-            .coerceAtLeast(1)
+        val largerDimensionPx = maxOf(containerWidth, containerHeight)
+        val zoomSectionSizePx = (largerDimensionPx * ZOOM_SECTION_RATIO).toInt().coerceAtLeast(1)
+        zoomSectionWidthPx = zoomSectionSizePx
+        zoomSectionHeightPx = zoomSectionSizePx
         zoomMarginXPx = (containerWidth * ZOOM_MARGIN_RATIO).toInt()
         zoomMarginYPx = (containerHeight * ZOOM_MARGIN_RATIO).toInt()
 
         binding.zoomPreviewContainer.layoutParams = FrameLayout.LayoutParams(
-            zoomSectionSizePx,
-            zoomSectionSizePx
+            zoomSectionWidthPx,
+            zoomSectionHeightPx
         )
         binding.zoomPreviewContainer.translationX = zoomMarginXPx.toFloat()
         binding.zoomPreviewContainer.translationY = zoomMarginYPx.toFloat()
@@ -142,7 +148,7 @@ internal class ImageCropFragment : BaseFragment() {
     private fun onPolygonCornerTouch(action: Int, rawX: Float, rawY: Float) {
         when (action) {
             MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE -> {
-                if (zoomSectionSizePx == 0) {
+                if (zoomSectionWidthPx == 0 || zoomSectionHeightPx == 0) {
                     initializeZoomPreviewSize()
                 }
                 updateZoomPreviewPosition(rawX, rawY)
@@ -161,20 +167,38 @@ internal class ImageCropFragment : BaseFragment() {
 
         val localTouchX = rawX - hostLocation[0]
         val localTouchY = rawY - hostLocation[1]
-        val centerX = binding.holderImageView.width / 2f
-        val centerY = binding.holderImageView.height / 2f
+        val width = binding.holderImageView.width.toFloat()
+        val height = binding.holderImageView.height.toFloat()
+        val switchStartRatio = (1f - ZOOM_DEAD_ZONE_RATIO) / 2f
+        val leftSwitchX = width * switchStartRatio
+        val rightSwitchX = width * (1f - switchStartRatio)
+        val topSwitchY = height * switchStartRatio
+        val bottomSwitchY = height * (1f - switchStartRatio)
 
-        val userInLeftHalf = localTouchX < centerX
-        val userInTopHalf = localTouchY < centerY
+        if (localTouchX <= leftSwitchX) {
+            previewOnRightSide = true
+        } else if (localTouchX >= rightSwitchX) {
+            previewOnRightSide = false
+        } else if (previewOnRightSide == null) {
+            previewOnRightSide = localTouchX < width / 2f
+        }
 
-        val previewX = if (userInLeftHalf) {
-            (binding.holderImageView.width - zoomSectionSizePx - zoomMarginXPx).toFloat()
+        if (localTouchY <= topSwitchY) {
+            previewOnBottomSide = true
+        } else if (localTouchY >= bottomSwitchY) {
+            previewOnBottomSide = false
+        } else if (previewOnBottomSide == null) {
+            previewOnBottomSide = localTouchY < height / 2f
+        }
+
+        val previewX = if (previewOnRightSide == true) {
+            (binding.holderImageView.width - zoomSectionWidthPx - zoomMarginXPx).toFloat()
         } else {
             zoomMarginXPx.toFloat()
         }
 
-        val previewY = if (userInTopHalf) {
-            (binding.holderImageView.height - zoomSectionSizePx - zoomMarginYPx).toFloat()
+        val previewY = if (previewOnBottomSide == true) {
+            (binding.holderImageView.height - zoomSectionHeightPx - zoomMarginYPx).toFloat()
         } else {
             zoomMarginYPx.toFloat()
         }
@@ -208,9 +232,10 @@ internal class ImageCropFragment : BaseFragment() {
         val sourceY =
             (normalizedY * imageBitmap.height).toInt().coerceIn(0, imageBitmap.height - 1)
 
-        val sampleSize = (zoomSectionSizePx / ZOOM_SCALE).toInt().coerceAtLeast(1)
-        val cropWidth = minOf(sampleSize, imageBitmap.width)
-        val cropHeight = minOf(sampleSize, imageBitmap.height)
+        val sampleWidth = (zoomSectionWidthPx / ZOOM_SCALE).toInt().coerceAtLeast(1)
+        val sampleHeight = (zoomSectionHeightPx / ZOOM_SCALE).toInt().coerceAtLeast(1)
+        val cropWidth = minOf(sampleWidth, imageBitmap.width)
+        val cropHeight = minOf(sampleHeight, imageBitmap.height)
 
         val cropLeft = (sourceX - cropWidth / 2).coerceIn(0, imageBitmap.width - cropWidth)
         val cropTop = (sourceY - cropHeight / 2).coerceIn(0, imageBitmap.height - cropHeight)
@@ -218,8 +243,8 @@ internal class ImageCropFragment : BaseFragment() {
         val croppedBitmap = Bitmap.createBitmap(imageBitmap, cropLeft, cropTop, cropWidth, cropHeight)
         val zoomedBitmap = Bitmap.createScaledBitmap(
             croppedBitmap,
-            zoomSectionSizePx,
-            zoomSectionSizePx,
+            zoomSectionWidthPx,
+            zoomSectionHeightPx,
             true
         )
 
@@ -229,6 +254,8 @@ internal class ImageCropFragment : BaseFragment() {
 
     private fun hideZoomPreview() {
         binding.zoomPreviewContainer.visibility = View.GONE
+        previewOnRightSide = null
+        previewOnBottomSide = null
     }
 
     private fun getScanActivity(): InternalScanActivity {

--- a/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/imagecrop/ImageCropFragment.kt
+++ b/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/imagecrop/ImageCropFragment.kt
@@ -32,6 +32,7 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.MotionEvent
 import android.widget.FrameLayout
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
@@ -50,6 +51,9 @@ internal class ImageCropFragment : BaseFragment() {
 
     companion object {
         private val TAG = ImageCropFragment::class.simpleName
+        private const val ZOOM_SCALE = 4f
+        private const val ZOOM_SECTION_RATIO = 0.2f
+        private const val ZOOM_MARGIN_RATIO = 0.025f
 
         fun newInstance(): ImageCropFragment {
             return ImageCropFragment()
@@ -59,6 +63,9 @@ internal class ImageCropFragment : BaseFragment() {
     private val nativeClass = OpenCvNativeBridge()
 
     private var selectedImage: Bitmap? = null
+    private var zoomSectionSizePx = 0
+    private var zoomMarginXPx = 0
+    private var zoomMarginYPx = 0
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -76,6 +83,10 @@ internal class ImageCropFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding.holderImageView.post {
+            initializeZoomPreviewSize()
+        }
 
         val sourceBitmap =
             BitmapFactory.decodeFile(getScanActivity().originalImageFile.absolutePath)
@@ -103,6 +114,121 @@ internal class ImageCropFragment : BaseFragment() {
         binding.confirmButton.setOnClickListener {
             onConfirmButtonClicked()
         }
+        binding.polygonView.onCornerTouchEvent = { action, rawX, rawY ->
+            onPolygonCornerTouch(action, rawX, rawY)
+        }
+    }
+
+    private fun initializeZoomPreviewSize() {
+        val containerWidth = binding.holderImageView.width
+        val containerHeight = binding.holderImageView.height
+        if (containerWidth <= 0 || containerHeight <= 0) {
+            return
+        }
+
+        zoomSectionSizePx = (minOf(containerWidth, containerHeight) * ZOOM_SECTION_RATIO).toInt()
+            .coerceAtLeast(1)
+        zoomMarginXPx = (containerWidth * ZOOM_MARGIN_RATIO).toInt()
+        zoomMarginYPx = (containerHeight * ZOOM_MARGIN_RATIO).toInt()
+
+        binding.zoomPreviewContainer.layoutParams = FrameLayout.LayoutParams(
+            zoomSectionSizePx,
+            zoomSectionSizePx
+        )
+        binding.zoomPreviewContainer.translationX = zoomMarginXPx.toFloat()
+        binding.zoomPreviewContainer.translationY = zoomMarginYPx.toFloat()
+    }
+
+    private fun onPolygonCornerTouch(action: Int, rawX: Float, rawY: Float) {
+        when (action) {
+            MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE -> {
+                if (zoomSectionSizePx == 0) {
+                    initializeZoomPreviewSize()
+                }
+                updateZoomPreviewPosition(rawX, rawY)
+                updateZoomPreviewImage(rawX, rawY)
+            }
+
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                hideZoomPreview()
+            }
+        }
+    }
+
+    private fun updateZoomPreviewPosition(rawX: Float, rawY: Float) {
+        val hostLocation = IntArray(2)
+        binding.holderImageView.getLocationOnScreen(hostLocation)
+
+        val localTouchX = rawX - hostLocation[0]
+        val localTouchY = rawY - hostLocation[1]
+        val centerX = binding.holderImageView.width / 2f
+        val centerY = binding.holderImageView.height / 2f
+
+        val userInLeftHalf = localTouchX < centerX
+        val userInTopHalf = localTouchY < centerY
+
+        val previewX = if (userInLeftHalf) {
+            (binding.holderImageView.width - zoomSectionSizePx - zoomMarginXPx).toFloat()
+        } else {
+            zoomMarginXPx.toFloat()
+        }
+
+        val previewY = if (userInTopHalf) {
+            (binding.holderImageView.height - zoomSectionSizePx - zoomMarginYPx).toFloat()
+        } else {
+            zoomMarginYPx.toFloat()
+        }
+
+        binding.zoomPreviewContainer.translationX = previewX
+        binding.zoomPreviewContainer.translationY = previewY
+    }
+
+    private fun updateZoomPreviewImage(rawX: Float, rawY: Float) {
+        val drawable = binding.imagePreview.drawable as? BitmapDrawable ?: return
+        val imageBitmap = drawable.bitmap ?: return
+        if (binding.imagePreview.width <= 0 || binding.imagePreview.height <= 0) {
+            return
+        }
+
+        val imageLocation = IntArray(2)
+        binding.imagePreview.getLocationOnScreen(imageLocation)
+        val imageLeft = imageLocation[0].toFloat()
+        val imageTop = imageLocation[1].toFloat()
+        val imageRight = imageLeft + binding.imagePreview.width
+        val imageBottom = imageTop + binding.imagePreview.height
+
+        if (rawX < imageLeft || rawX > imageRight || rawY < imageTop || rawY > imageBottom) {
+            hideZoomPreview()
+            return
+        }
+
+        val normalizedX = ((rawX - imageLeft) / binding.imagePreview.width).coerceIn(0f, 1f)
+        val normalizedY = ((rawY - imageTop) / binding.imagePreview.height).coerceIn(0f, 1f)
+        val sourceX = (normalizedX * imageBitmap.width).toInt().coerceIn(0, imageBitmap.width - 1)
+        val sourceY =
+            (normalizedY * imageBitmap.height).toInt().coerceIn(0, imageBitmap.height - 1)
+
+        val sampleSize = (zoomSectionSizePx / ZOOM_SCALE).toInt().coerceAtLeast(1)
+        val cropWidth = minOf(sampleSize, imageBitmap.width)
+        val cropHeight = minOf(sampleSize, imageBitmap.height)
+
+        val cropLeft = (sourceX - cropWidth / 2).coerceIn(0, imageBitmap.width - cropWidth)
+        val cropTop = (sourceY - cropHeight / 2).coerceIn(0, imageBitmap.height - cropHeight)
+
+        val croppedBitmap = Bitmap.createBitmap(imageBitmap, cropLeft, cropTop, cropWidth, cropHeight)
+        val zoomedBitmap = Bitmap.createScaledBitmap(
+            croppedBitmap,
+            zoomSectionSizePx,
+            zoomSectionSizePx,
+            true
+        )
+
+        binding.zoomPreviewImage.setImageBitmap(zoomedBitmap)
+        binding.zoomPreviewContainer.visibility = View.VISIBLE
+    }
+
+    private fun hideZoomPreview() {
+        binding.zoomPreviewContainer.visibility = View.GONE
     }
 
     private fun getScanActivity(): InternalScanActivity {

--- a/DocumentScanner/src/main/res/layout/fragment_image_crop.xml
+++ b/DocumentScanner/src/main/res/layout/fragment_image_crop.xml
@@ -32,6 +32,36 @@
             android:layout_height="match_parent"
             android:visibility="gone" />
 
+        <FrameLayout
+            android:id="@+id/zoomPreviewContainer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@android:color/black"
+            android:visibility="gone">
+
+            <ImageView
+                android:id="@+id/zoomPreviewImage"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:contentDescription="@string/preview_image"
+                android:scaleType="fitXY" />
+
+            <View
+                android:id="@+id/zoomPreviewCrosshairVertical"
+                android:layout_width="1dp"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:background="@android:color/white" />
+
+            <View
+                android:id="@+id/zoomPreviewCrosshairHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_gravity="center"
+                android:background="@android:color/white" />
+
+        </FrameLayout>
+
     </FrameLayout>
 
     <RelativeLayout


### PR DESCRIPTION
## Summary

I've been using the document scanning functionality inside the Nextcloud Android app for a while and noticed that they use this repository as the upstream dependency:

https://github.com/nextcloud/android/blob/1048746b95131dce17991a790590a29a3af3a65a/gradle/libs.versions.toml#L99

I've had trouble selecting corners, as lifting my finger to end the touch causes micro-jitters, which distort the actual position I wanted to select.

This change adds a zoomed-in area to the corner of the screen with a cross-hair, that allows more precise corner selection.  
The area also moves to another corner, if the user attempts to place the corner there.  
The exact position is also offset by the systems "touch slop" parameters, which causes a slight delay, if the user remains steady in a location: https://developer.android.com/develop/ui/views/touch-and-input/gestures/viewgroup

## Demo

https://github.com/user-attachments/assets/5f2733b4-d13e-4965-a77b-0814e20b1d65

As this repository has Issues deactivated, I hope opening a Pull Request with an implementation of a feature request is acceptable.
